### PR TITLE
fix glide load image looper call onMeasure and display image method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
@@ -14,6 +15,7 @@ apply plugin: 'com.jfrog.bintray'
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,13 +5,13 @@ apply plugin: 'com.jfrog.bintray'
 version = "1.1.1"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     resourcePrefix "ninegridimageview__"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/library/src/main/java/com/jaeger/ninegridimageview/NineGridImageView.java
+++ b/library/src/main/java/com/jaeger/ninegridimageview/NineGridImageView.java
@@ -61,7 +61,6 @@ public class NineGridImageView<T> extends ViewGroup {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         int width = MeasureSpec.getSize(widthMeasureSpec);
         int height = MeasureSpec.getSize(heightMeasureSpec);
         int totalWidth = width - getPaddingLeft() - getPaddingRight();
@@ -124,9 +123,6 @@ public class NineGridImageView<T> extends ViewGroup {
             right = left + mGridSize;
             bottom = top + mGridSize;
             childrenView.layout(left, top, right, bottom);
-            if (mAdapter != null) {
-                mAdapter.onDisplayImage(getContext(), childrenView, mImgDataList.get(i));
-            }
         }
     }
 
@@ -194,9 +190,6 @@ public class NineGridImageView<T> extends ViewGroup {
                     break;
                 default:
                     break;
-            }
-            if (mAdapter != null) {
-                mAdapter.onDisplayImage(getContext(), childrenView, mImgDataList.get(i));
             }
         }
     }
@@ -280,9 +273,6 @@ public class NineGridImageView<T> extends ViewGroup {
                     break;
                 default:
                     break;
-            }
-            if (mAdapter != null) {
-                mAdapter.onDisplayImage(getContext(), childrenView, mImgDataList.get(i));
             }
         }
     }
@@ -381,9 +371,6 @@ public class NineGridImageView<T> extends ViewGroup {
                     break;
                 default:
                     break;
-            }
-            if (mAdapter != null) {
-                mAdapter.onDisplayImage(getContext(), childrenView, mImgDataList.get(i));
             }
         }
     }
@@ -498,9 +485,6 @@ public class NineGridImageView<T> extends ViewGroup {
                 default:
                     break;
             }
-            if (mAdapter != null) {
-                mAdapter.onDisplayImage(getContext(), childrenView, mImgDataList.get(i));
-            }
         }
     }
 
@@ -596,7 +580,21 @@ public class NineGridImageView<T> extends ViewGroup {
             }
         }
         mImgDataList = lists;
-        requestLayout();
+        updateDisplayImage();
+    }
+
+    /**
+     * 更新 ImageView 显示 url
+     */
+    private void updateDisplayImage() {
+        if (mImgDataList == null) return;
+        int showChildrenCount = getNeedShowCount(mImgDataList.size());
+        for (int i = 0; i < showChildrenCount; i++) {
+            ImageView childrenView = (ImageView) getChildAt(i);
+            if (childrenView != null && mAdapter != null) {
+                mAdapter.onDisplayImage(getContext(), childrenView, mImgDataList.get(i));
+            }
+        }
     }
 
     private int getNeedShowCount(int size) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.jaeger.ninegridimgdemo"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -23,8 +23,8 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:recyclerview-v7:26.1.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.jaeger.ninegridimageview:library:1.1.1'
 //            compile project(':library')


### PR DESCRIPTION
使用glide加载图片，发现无法显示，打印 NineGridImageView OnMeasure 与 Adapter 回掉的 displayImage 日志，发现他们都在疯狂的调用... 然后，我把原来显示图片的回调displayImage 从layout 方法中 移动到 setImageListData 方法中，就能正常工作了，所以提一个pr